### PR TITLE
Warning to error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 				"cmake.configureOnOpen": true,
 				"cmake.generator": "Ninja",
 				"cmake.configureSettings": {
-					"CMAKE_TOOLCHAIN_FILE": "${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+					"CMAKE_TOOLCHAIN_FILE": "/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake"
 				}
 			},
 			"extensions": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(cpp-template VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(Protobuf REQUIRED)
+find_package(GTest REQUIRED)
 
 include_directories(${Protobuf_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 find_package(Protobuf REQUIRED)
 find_package(GTest REQUIRED)
 
-include_directories(${Protobuf_INCLUDE_DIRS})
-
-include_directories(config controller hal)
+option(STRICT_BUILD "Enable warnings as errors" ON)
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,20 +1,16 @@
-# find_library(Protobuf_LIBRARIES NAMES protobuf libprotobuf)
-# find_path(Protobuf_INCLUDE_DIRS google/protobuf/stubs/common.h) 
-
-# if(Protobuf_LIBRARIES AND Protobuf_INCLUDE_DIRS)
-#   set(Protobuf_FOUND TRUE)
-# endif()
-
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS proto/actuators.proto proto/sensors.proto)
 add_subdirectory(config)
 add_subdirectory(controller)
 add_subdirectory(hal)
+add_subdirectory(proto)
 
-add_executable(Controller main.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+add_executable(Controller main.cpp)
+
 target_link_libraries(Controller 
                     ConfigLib
                     ControllerLib
                     HalLib
-                    ${Protobuf_LIBRARIES})
+                    )
+
+if(STRICT_BUILD)
+    target_compile_options(Controller PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif(STRICT_BUILD)

--- a/src/hal/ActuatorInterface.h
+++ b/src/hal/ActuatorInterface.h
@@ -12,8 +12,6 @@
 #ifndef ACTUATOR_H
 #define ACTUATOR_H
 
-#include <google/protobuf/message.h>
-
 namespace Hal {
 
 template <typename ActuatorInputType>

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,13 +1,14 @@
-# add_library(ProtoLib)
+add_library(ProtoLib)
 
-# target_sources(ProtoLib
-#   PRIVATE
-#     ${CMAKE_CURRENT_LIST_DIR}/sensors.pb.cc
-#   PUBLIC
-#     ${CMAKE_CURRENT_LIST_DIR}/sensors.pb.h
-#     )
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS actuators.proto)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS sensors.proto)
 
-# target_include_directories(ProtoLib
-#   PUBLIC
-#     ${CMAKE_CURRENT_LIST_DIR}
-#     )
+target_sources(ProtoLib
+  PRIVATE
+    ${PROTO_SRCS}
+  PUBLIC
+    ${PROTO_HDRS}
+    )
+
+target_link_libraries(ProtoLib 
+                      protobuf::libprotobuf)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,3 @@
-include(FetchContent)
-
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.12.1
-)
-FetchContent_MakeAvailable(googletest)
-
 enable_testing()
 
 add_subdirectory(config)

--- a/test/config/CMakeLists.txt
+++ b/test/config/CMakeLists.txt
@@ -6,5 +6,8 @@ add_executable(ConfigTest ${ConfigTestSources})
 
 target_link_libraries(ConfigTest 
                     ConfigLib
+                    GTest::gmock
+                    GTest::gmock_main
+                    GTest::gtest
                     GTest::gtest_main
                     )

--- a/test/controller/CMakeLists.txt
+++ b/test/controller/CMakeLists.txt
@@ -6,5 +6,8 @@ add_executable(ControllerTest ${ControllerTestSources})
 
 target_link_libraries(ControllerTest 
                     ControllerLib
+                    GTest::gmock
+                    GTest::gmock_main
+                    GTest::gtest
                     GTest::gtest_main
                     )

--- a/test/hal/CMakeLists.txt
+++ b/test/hal/CMakeLists.txt
@@ -7,5 +7,8 @@ add_executable(HalTest ${HalTestSources})
 
 target_link_libraries(HalTest 
                     HalLib
+                    GTest::gmock
+                    GTest::gmock_main
+                    GTest::gtest
                     GTest::gtest_main
                     )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "dependencies": [
-    "protobuf"
+    "protobuf",
+    "gtest"
   ]
 }


### PR DESCRIPTION
First review and if it's all fine, then merge PR #16. This PR was built on top of that PR.
I broke the build on purpose, which you can merge for now. But I think it's a good exercise for you to check all warnings from compiler and correct them, this strategy has taught me a lot of C++.
Of course, any question I'll be here to help 😄 
Btw, if you're annoyed with all these errors, you can locally change:
```cmake
option(STRICT_BUILD "Enable warnings as errors" ON)
```
to
```cmake
option(STRICT_BUILD "Enable warnings as errors" OFF)
```