### PR TITLE
Resolving compiler errors after flag change

### DIFF
--- a/src/hal/ActuatorInterface.h
+++ b/src/hal/ActuatorInterface.h
@@ -12,7 +12,7 @@
 #ifndef ACTUATOR_H
 #define ACTUATOR_H
 
-namespace Hal {
+namespace hal {
 
 template <typename ActuatorInputType>
 class ActuatorInterface {
@@ -25,5 +25,5 @@ public:
     virtual void SetState(ActuatorInputType state) = 0;
     virtual ~ActuatorInterface() = default;
 };
-}
+} // namespace hal
 #endif // ACTUATOR_H

--- a/src/hal/ActuatorInterface.h
+++ b/src/hal/ActuatorInterface.h
@@ -23,7 +23,7 @@ public:
      * @param state Value to set the actuator's state with
      */
     virtual void SetState(ActuatorInputType state) = 0;
-    virtual ~ActuatorInterface() {};
+    virtual ~ActuatorInterface() = default;
 };
 }
 #endif // ACTUATOR_H

--- a/src/hal/ActuatorInterface.h
+++ b/src/hal/ActuatorInterface.h
@@ -23,6 +23,7 @@ public:
      * @param state Value to set the actuator's state with
      */
     virtual void SetState(ActuatorInputType state) = 0;
+    virtual ~ActuatorInterface() {};
 };
 }
 #endif // ACTUATOR_H

--- a/src/hal/AngleSensor.cpp
+++ b/src/hal/AngleSensor.cpp
@@ -1,16 +1,16 @@
 #include "AngleSensor.h"
 
-namespace Hal {
+namespace hal {
 
 namespace {
-    const double kMinAngle = 0.0;
-    const double kMaxAngle = 360.0;
+    const double kMinAngle_ = 0.0;
+    const double kMaxAngle_ = 360.0;
 }
 
 AngleSensor::AngleSensor(double initialAngle)
     : angle_(initialAngle)
-    , kMinAngle(0.0)
-    , kMaxAngle(360.0)
+    , kMinAngle_(0.0)
+    , kMaxAngle_(360.0)
 {
 }
 

--- a/src/hal/AngleSensor.h
+++ b/src/hal/AngleSensor.h
@@ -3,7 +3,7 @@
 
 #include "SensorInterface.h"
 
-namespace Hal {
+namespace hal {
 
 // int is just a placeholder
 class AngleSensor : public SensorInterface<double, int> {
@@ -12,10 +12,10 @@ public:
     [[nodiscard]] double GetValue(int /* unused */) override;
 
 private:
-    const double kMinAngle;
-    const double kMaxAngle;
+    const double kMinAngle_;
+    const double kMaxAngle_;
     double angle_;
 };
 
-}
+} // namespace hal
 #endif // ANGLE_SENSOR_H

--- a/src/hal/DCMotor.cpp
+++ b/src/hal/DCMotor.cpp
@@ -1,6 +1,6 @@
 #include "DCMotor.h"
 
-namespace Hal {
+namespace hal {
 
 DCMotor::DCMotor(double initialState)
     : motorState_(initialState)
@@ -12,4 +12,4 @@ void DCMotor::SetState(double state)
     motorState_ = state;
 }
 
-}
+} // namespace hal

--- a/src/hal/DCMotor.h
+++ b/src/hal/DCMotor.h
@@ -3,7 +3,7 @@
 
 #include "ActuatorInterface.h"
 
-namespace Hal {
+namespace hal {
 
 class DCMotor : public ActuatorInterface<double> {
 public:
@@ -14,6 +14,6 @@ private:
     double motorState_;
 };
 
-}
+} // namespace hal
 
 #endif // DC_MOTOR_H

--- a/src/hal/SensorInterface.h
+++ b/src/hal/SensorInterface.h
@@ -11,7 +11,7 @@
 #ifndef SENSOR_H
 #define SENSOR_H
 
-namespace Hal {
+namespace hal {
 
 template <typename SensorReturnType, typename SensorInputType>
 class SensorInterface {
@@ -24,5 +24,5 @@ public:
     virtual SensorReturnType GetValue(SensorInputType) = 0;
 };
 
-}
+} // namespace hal
 #endif // SENSOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,11 @@
 #include <iostream>
 #include <memory>
 
-int main(int, char**)
+int main(int /*unused*/, char** /*unused*/)
 {
-    auto dc_motor = std::make_unique<Hal::DCMotor>(0.0);
+    auto dc_motor = std::make_unique<hal::DCMotor>(0.0);
 
-    [[gnu::unused]] auto angle_sensor = Hal::AngleSensor(0.0);
+    [[gnu::unused]] auto angle_sensor = hal::AngleSensor(0.0);
 
     [[gnu::unused]] auto configuration = Configuration();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,11 +9,11 @@ int main(int, char**)
 {
     auto dc_motor = std::make_unique<Hal::DCMotor>(0.0);
 
-    auto angle_sensor = Hal::AngleSensor(0.0);
+    [[gnu::unused]] auto angle_sensor = Hal::AngleSensor(0.0);
 
-    auto configuration = Configuration();
+    [[gnu::unused]] auto configuration = Configuration();
 
-    auto controller = Controller();
+    [[gnu::unused]] auto controller = Controller();
 
     return 0;
 }

--- a/test/hal/AngleSensorTest.cpp
+++ b/test/hal/AngleSensorTest.cpp
@@ -3,7 +3,7 @@
 
 TEST(AngleSensorTest, DummyTest)
 {
-    auto* angle_sensor = new Hal::AngleSensor(42.0);
+    auto* angle_sensor = new hal::AngleSensor(42.0);
 
     EXPECT_EQ(angle_sensor->GetValue(1), 42.0);
 }


### PR DESCRIPTION
Refers to [issue #6](https://github.com/Open-Source-Digital-Twin/inverted-pendulum-controller/issues/6).

Added a few changes based on clang readability suggestions.