### PR TITLE
Add spdlog and abseil as dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(Protobuf REQUIRED)
 find_package(GTest REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
+find_package(absl CONFIG REQUIRED)
 
 option(STRICT_BUILD "Enable warnings as errors" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(Controller
                     ConfigLib
                     ControllerLib
                     HalLib
+                    spdlog::spdlog
+                    absl::strings
                     )
 
 if(STRICT_BUILD)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,21 @@
 #include "Configuration.h"
 #include "Controller.h"
 #include "DCMotor.h"
+#include "absl/strings/str_join.h"
+#include "spdlog/spdlog.h"
 #include <iostream>
 #include <memory>
+#include <vector>
 
 int main(int /*unused*/, char** /*unused*/)
 {
+    std::vector<std::string> v = { "foo", "bar", "baz" };
+    std::string s = absl::StrJoin(v, "-");
+
+    spdlog::info("Starting controller.");
+
+    spdlog::warn("Checking if abseil is working: {}", s);
+
     auto dc_motor = std::make_unique<hal::DCMotor>(0.0);
 
     [[gnu::unused]] auto angle_sensor = hal::AngleSensor(0.0);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,8 @@
 {
   "dependencies": [
     "protobuf",
-    "gtest"
+    "gtest",
+    "spdlog",
+    "abseil"
   ]
 }


### PR DESCRIPTION
I added two new dependecies.
The most important one is [spdlog](https://github.com/gabime/spdlog), which is super easy to use for logging.
The second one is [abseil](https://abseil.io/), which can help us for some tasks.
I also created some basic code using both of them.
The main idea is to spread spdlog as our log tool and dump into a file instead of stdout.

NB: I added on the highest level of CMakeLists.txt just as POC. As the project goes, we can move to a specific library.