### PR TITLE
Add setting on configuration with variant type

### DIFF
--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -4,6 +4,7 @@
 #include "ConfigurationInterface.h"
 #include <filesystem>
 #include <nlohmann/json.hpp>
+
 using json = nlohmann::json;
 
 namespace config {
@@ -12,7 +13,7 @@ public:
     explicit Configuration(std::filesystem::path filepath);
     [[nodiscard]] bool LoadConfigurationFile() override;
     [[nodiscard]] bool WriteConfigurationFile(json& jsonfile) override;
-    [[nodiscard]] json GetConfiguration(std::string& configName) override;
+    [[nodiscard]] Setting GetSetting(ConfigurationName config_name) override;
     [[nodiscard]] bool CreateDefaultConfigurationFile();
 
 private:
@@ -20,5 +21,54 @@ private:
     json configData_;
 };
 } // namespace config
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+template <typename T>
+struct adl_serializer<std::optional<T>> {
+    static void from_json(const json& j, std::optional<T>& opt)
+    {
+        if (j.is_null()) {
+            opt = std::nullopt;
+        }
+        else {
+            opt = j.get<T>();
+        }
+    }
+    static void to_json(json& json, std::optional<T> t)
+    {
+        if (t) {
+            json = *t;
+        }
+        else {
+            json = nullptr;
+        }
+    }
+};
+
+template <typename T, typename... Ts>
+void variant_from_json(const nlohmann::json& j, std::variant<Ts...>& data)
+{
+    try {
+        data = j.get<T>();
+    }
+    catch (...) {
+    }
+}
+
+template <typename... Ts>
+struct adl_serializer<std::variant<Ts...>> {
+    static void to_json(nlohmann::json& j, const std::variant<Ts...>& data)
+    {
+        std::visit([&j](const auto& v) { j = v; }, data);
+    }
+
+    static void from_json(const nlohmann::json& j, std::variant<Ts...>& data)
+    {
+        (variant_from_json<Ts>(j, data), ...);
+    }
+};
+
+NLOHMANN_JSON_NAMESPACE_END
 
 #endif // CONFIGURATION_H

--- a/src/config/ConfigurationDefault.h
+++ b/src/config/ConfigurationDefault.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Setting.h"
+#include <cmath>
+#include <optional>
+#include <vector>
+
+namespace config {
+
+const std::vector<Setting> kDefaultConfig = {
+    { ConfigurationName::kAngleSensorMaxValue,
+        M_PIf,
+        std::nullopt,
+        std::nullopt,
+        "rad",
+        "Maximum value of sensor's range" },
+    { ConfigurationName::kAngleSensorMinValue,
+        -M_PIf,
+        std::nullopt,
+        std::nullopt,
+        "rad",
+        "Minimum value of sensor's range" },
+};
+
+} // namespace config

--- a/src/config/ConfigurationInterface.h
+++ b/src/config/ConfigurationInterface.h
@@ -1,6 +1,7 @@
 #ifndef CONFIGURATION_INTERFACE_H
 #define CONFIGURATION_INTERFACE_H
-#include "ConfigurationNameEnum.h"
+#include "ConfigurationName.h"
+#include "Setting.h"
 #include <string>
 
 namespace config {
@@ -28,9 +29,10 @@ public:
      * @param ConfigName
      * @return ConfigurationFileType
      */
-    virtual ConfigurationFileType GetConfiguration(std::string& configName) = 0;
+    virtual Setting GetSetting(ConfigurationName config_name) = 0;
     virtual ~ConfigurationInterface() = default;
 };
+
 } // namespace config
 
 #endif // CONFIGURATION_INTERFACE_H

--- a/src/config/ConfigurationName.h
+++ b/src/config/ConfigurationName.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <ostream>
+
+namespace config {
+
+enum class ConfigurationName {
+    kAngleSensorMaxValue,
+    kAngleSensorMinValue,
+    kAngleSensorMaxVoltage,
+    kAngleSensorMinVoltage,
+    kDcMotorMaxVoltage,
+    kDcMotorMinVoltage,
+    kDcMotorTorque,
+    kDcMotorSpeed
+};
+
+inline std::string ToString(ConfigurationName config_name)
+{
+    switch (config_name) {
+    case ConfigurationName::kAngleSensorMaxValue:
+        return "kAngleSensorMaxValue";
+    case ConfigurationName::kAngleSensorMinValue:
+        return "kAngleSensorMinValue";
+    case ConfigurationName::kAngleSensorMaxVoltage:
+        return "kAngleSensorMaxVoltage";
+    case ConfigurationName::kAngleSensorMinVoltage:
+        return "kAngleSensorMinVoltage";
+    case ConfigurationName::kDcMotorMaxVoltage:
+        return "kDcMotorMaxVoltage";
+    case ConfigurationName::kDcMotorMinVoltage:
+        return "kDcMotorMinVoltage";
+    case ConfigurationName::kDcMotorTorque:
+        return "kDcMotorTorque";
+    case ConfigurationName::kDcMotorSpeed:
+        return "kDcMotorSpeed";
+    } // Don't add the default case, so that the compiler can warn you.
+}
+
+inline std::ostream& operator<<(std::ostream& ostream, const ConfigurationName& config_name)
+{
+    ostream << ToString(config_name);
+    return ostream;
+}
+
+} // namespace config

--- a/src/config/ConfigurationNameEnum.h
+++ b/src/config/ConfigurationNameEnum.h
@@ -1,6 +1,0 @@
-namespace config {
-enum ConfigurationNameEnum {
-    kAngleSensorConfiguration,
-    kDcMotorConfiguration
-};
-}

--- a/src/config/Setting.h
+++ b/src/config/Setting.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ConfigurationName.h"
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace config {
+
+using SettingValueType = std::variant<int, float>;
+
+struct Setting {
+    ConfigurationName name;
+    SettingValueType value;
+    std::optional<SettingValueType> max_value;
+    std::optional<SettingValueType> min_value;
+    std::optional<std::string> unit;
+    std::optional<std::string> description;
+
+public:
+    template <typename T>
+    T Value() const
+    {
+        // Check if the variant holds a value of type T
+        if (std::holds_alternative<T>(this->value)) {
+            return std::get<T>(this->value);
+        }
+        // If not, throw an exception
+        throw std::bad_variant_access();
+    }
+};
+
+} // namespace config

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "AngleSensor.h"
 #include "Configuration.h"
+#include "ConfigurationName.h"
 #include "Controller.h"
 #include "DCMotor.h"
 #include "absl/strings/str_join.h"
@@ -21,17 +22,15 @@ int main(int /*unused*/, char** /*unused*/)
     [[gnu::unused]] auto angle_sensor = hal::AngleSensor(0.0);
     [[gnu::unused]] auto controller = Controller();
 
-    config::Configuration config("/workspaces/HAL-controller-test/config.json");
-    std::string targetConfigName = "angleSensorConfig2";
-    json targetConfig = config.GetConfiguration(targetConfigName);
+    config::Configuration config("/workspaces/inverted-pendulum-controller/config.json");
+    auto target_config = config.GetSetting(config::ConfigurationName::kAngleSensorMaxValue).Value<float>();
+    spdlog::critical("Getting config: {}", target_config);
 
-    if (!targetConfig.empty()) {
-        std::cout << "Configuration Name: " << targetConfig["Name"] << std::endl;
-        std::cout << "MaxValue: " << targetConfig["MaxValue"] << std::endl;
-        std::cout << "MinValue: " << targetConfig["MinValue"] << std::endl;
-        std::cout << "DefaultValue: " << targetConfig["DefaultValue"] << std::endl;
-        std::cout << "Description: " << targetConfig["Description"] << std::endl;
-    }
+    // If we try to get value as int, it'll throw an exception
+    // auto int_config = config.GetSetting(config::ConfigurationName::kAngleSensorMaxValue).Value<int>();
+
+    // If we try to get value of a non existing config, it'll show all available configs and throw an exception
+    // [[gnu::unused]] auto motor_config = config.GetSetting(config::ConfigurationName::kDcMotorSpeed).Value<float>();
 
     return 0;
 }


### PR DESCRIPTION
I started this PR as POC for getting our configurations in a more explicit way:
```cpp
T variable = Configuration::GetSetting(config::ConfigurationName).Value<T>();
```
We have a mix of compile time and runtime checks, which let us know if we're getting the correct type for our data, also if the name of config can be retrieved using a default setting.
I'd like your review on this, but I also left some `TODOs` on the way.

The main idea of these changes is to detach the config interface from json and leave it to the concrete class. And finally we'll add a mock example with this class and make it wasy to manipulate.

NB: I know I'm trying to kill a fly with a cannon with these changes, but I really would love to get a clean config class so we can reach to the point that we can compile it to a MCU and flash without memory issues. 💪  