### PR TITLE
Google benchmark setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,12 @@ find_package(GTest REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(benchmark CONFIG REQUIRED)
 
 option(STRICT_BUILD "Enable warnings as errors" ON)
 
 add_subdirectory(src)
-
+add_subdirectory(benchmark)
 add_subdirectory(test)
 include(CTest)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(
+  benchmarkPOC
+  benchmarkPOC.cpp
+)
+
+target_link_libraries(
+    benchmarkPOC
+    PRIVATE 
+        benchmark::benchmark
+)

--- a/benchmark/benchmarkPOC.cpp
+++ b/benchmark/benchmarkPOC.cpp
@@ -1,5 +1,6 @@
 #include <benchmark/benchmark.h>
 
+//Just a placeholder
 static void BM_StringCreation(benchmark::State& state)
 {
     for (auto _ : state) {
@@ -10,3 +11,19 @@ static void BM_StringCreation(benchmark::State& state)
 BENCHMARK(BM_StringCreation);
 
 BENCHMARK_MAIN();
+
+//Output example
+// 2023-11-08T16:10:32+00:00
+// Running /workspaces/inverted-pendulum-controller/build/benchmark/benchmarkPOC
+// Run on (12 X 4287.79 MHz CPU s)
+// CPU Caches:
+//   L1 Data 32 KiB (x6)
+//   L1 Instruction 32 KiB (x6)
+//   L2 Unified 512 KiB (x6)
+//   L3 Unified 16384 KiB (x1)
+// Load Average: 0.93, 0.96, 1.00
+// ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+// ------------------------------------------------------------
+// Benchmark                  Time             CPU   Iterations
+// ------------------------------------------------------------
+// BM_StringCreation       1.24 ns         1.24 ns    578543877

--- a/benchmark/benchmarkPOC.cpp
+++ b/benchmark/benchmarkPOC.cpp
@@ -1,6 +1,6 @@
 #include <benchmark/benchmark.h>
 
-//Just a placeholder
+// Just a placeholder
 static void BM_StringCreation(benchmark::State& state)
 {
     for (auto _ : state) {
@@ -12,18 +12,18 @@ BENCHMARK(BM_StringCreation);
 
 BENCHMARK_MAIN();
 
-//Output example
-// 2023-11-08T16:10:32+00:00
-// Running /workspaces/inverted-pendulum-controller/build/benchmark/benchmarkPOC
-// Run on (12 X 4287.79 MHz CPU s)
-// CPU Caches:
-//   L1 Data 32 KiB (x6)
-//   L1 Instruction 32 KiB (x6)
-//   L2 Unified 512 KiB (x6)
-//   L3 Unified 16384 KiB (x1)
-// Load Average: 0.93, 0.96, 1.00
-// ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-// ------------------------------------------------------------
-// Benchmark                  Time             CPU   Iterations
-// ------------------------------------------------------------
-// BM_StringCreation       1.24 ns         1.24 ns    578543877
+// Output example
+//  2023-11-08T16:10:32+00:00
+//  Running /workspaces/inverted-pendulum-controller/build/benchmark/benchmarkPOC
+//  Run on (12 X 4287.79 MHz CPU s)
+//  CPU Caches:
+//    L1 Data 32 KiB (x6)
+//    L1 Instruction 32 KiB (x6)
+//    L2 Unified 512 KiB (x6)
+//    L3 Unified 16384 KiB (x1)
+//  Load Average: 0.93, 0.96, 1.00
+//  ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+//  ------------------------------------------------------------
+//  Benchmark                  Time             CPU   Iterations
+//  ------------------------------------------------------------
+//  BM_StringCreation       1.24 ns         1.24 ns    578543877

--- a/benchmark/benchmarkPOC.cpp
+++ b/benchmark/benchmarkPOC.cpp
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 
-static void BM_StringCreation(benchmark::State& state) {
+static void BM_StringCreation(benchmark::State& state)
+{
     for (auto _ : state) {
         std::string empty_string;
         benchmark::DoNotOptimize(empty_string);

--- a/benchmark/benchmarkPOC.cpp
+++ b/benchmark/benchmarkPOC.cpp
@@ -1,0 +1,11 @@
+#include <benchmark/benchmark.h>
+
+static void BM_StringCreation(benchmark::State& state) {
+    for (auto _ : state) {
+        std::string empty_string;
+        benchmark::DoNotOptimize(empty_string);
+    }
+}
+BENCHMARK(BM_StringCreation);
+
+BENCHMARK_MAIN();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@ int main(int /*unused*/, char** /*unused*/)
 
     spdlog::warn("Checking if abseil is working: {}", s);
 
+    spdlog::info("Instantiating motor, sensor and controller.");
     auto dc_motor = std::make_unique<hal::DCMotor>(0.0);
     [[gnu::unused]] auto angle_sensor = hal::AngleSensor(0.0);
     [[gnu::unused]] auto controller = Controller();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
     "gtest",
     "spdlog",
     "abseil",
-    "nlohmann-json"
+    "nlohmann-json",
+    "benchmark"
   ]
 }


### PR DESCRIPTION
POC  with a dummy empty string generator test function.
I ran the new target in both debug and release mode and it seems to work just fine out of the box.

![Screenshot from 2023-11-08 17-09-38](https://github.com/Open-Source-Digital-Twin/inverted-pendulum-controller/assets/54245866/1b8a22e9-b727-4599-8f39-5b5ebd91a39f)
