### PR TITLE
Removing <json> from the Controller's contructor

### DIFF
--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -3,19 +3,6 @@
 
 namespace controller {
 
-// template <typename ConfigFileType>
-// Controller::Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
-//     : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
-//     , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
-//     , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
-//     , error_(0.0)
-//     , previous_error_(0.0)
-//     , integral_part_(0.0)
-//     , output_(0.0)
-//     , dt_(dt)
-// {
-// }
-
 void Controller::Read(double error)
 {
     this->error_ = error;

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -3,18 +3,18 @@
 
 namespace controller {
 
-template <typename ConfigFileType>
-Controller::Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
-    : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
-    , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
-    , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
-    , error_(0.0)
-    , previous_error_(0.0)
-    , integral_part_(0.0)
-    , output_(0.0)
-    , dt_(dt)
-{
-}
+// template <typename ConfigFileType>
+// Controller::Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
+//     : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
+//     , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
+//     , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
+//     , error_(0.0)
+//     , previous_error_(0.0)
+//     , integral_part_(0.0)
+//     , output_(0.0)
+//     , dt_(dt)
+// {
+// }
 
 void Controller::Read(double error)
 {

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -3,10 +3,11 @@
 
 namespace controller {
 
-Controller::Controller(config::ConfigurationInterface<json>& config, std::chrono::microseconds dt)
-    : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).Value<double>())
-    , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).Value<double>())
-    , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).Value<double>())
+template <typename ConfigFileType>
+Controller::Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
+    : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
+    , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
+    , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
     , error_(0.0)
     , previous_error_(0.0)
     , integral_part_(0.0)

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -5,11 +5,13 @@
 #include "ConfigurationInterface.h"
 #include "ControllerInterface.h"
 #include <chrono>
+
 namespace controller {
 
 class Controller : ControllerInterface<double, double> {
 public:
-    explicit Controller(config::ConfigurationInterface<json>& config, std::chrono::microseconds dt);
+    template <typename ConfigFileType>
+    explicit Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt);
     ~Controller() override = default;
     void Read(double error) override;
     [[nodiscard]] double Write() override;

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -27,10 +27,10 @@ private:
     double kp_;
     double ki_;
     double kd_;
-    double integral_part_{};
-    double output_{};
-    double error_{};
-    double previous_error_{};
+    double integral_part_ {};
+    double output_ {};
+    double error_ {};
+    double previous_error_ {};
     std::chrono::microseconds dt_;
 };
 

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -10,8 +10,20 @@ namespace controller {
 
 class Controller : ControllerInterface<double, double> {
 public:
+    // template <typename ConfigFileType>
+    // explicit Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt);
     template <typename ConfigFileType>
-    explicit Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt);
+    Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
+        : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
+        , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
+        , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
+        , integral_part_(0.0)
+        , output_(0.0)
+        , error_(0.0)
+        , previous_error_(0.0)
+        , dt_(dt)
+    {
+    }
     ~Controller() override = default;
     void Read(double error) override;
     [[nodiscard]] double Write() override;

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -10,17 +10,11 @@ namespace controller {
 
 class Controller : ControllerInterface<double, double> {
 public:
-    // template <typename ConfigFileType>
-    // explicit Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt);
     template <typename ConfigFileType>
     Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
         : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
         , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
         , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
-        , integral_part_(0.0)
-        , output_(0.0)
-        , error_(0.0)
-        , previous_error_(0.0)
         , dt_(dt)
     {
     }
@@ -33,10 +27,10 @@ private:
     double kp_;
     double ki_;
     double kd_;
-    double integral_part_;
-    double output_;
-    double error_;
-    double previous_error_;
+    double integral_part_{};
+    double output_{};
+    double error_{};
+    double previous_error_{};
     std::chrono::microseconds dt_;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ int main(int /*unused*/, char** /*unused*/)
     [[gnu::unused]] auto angle_sensor = hal::AngleSensor(0.0);
 
     config::Configuration config("/workspaces/inverted-pendulum-controller/config.json");
+
     // auto target_config = config.GetSetting(config::ConfigurationName::kAngleSensorMaxValue).Value<float>();
     // spdlog::critical("Getting config: {}", target_config);
 


### PR DESCRIPTION
Templating one of the the Controller constructor's parameters meant moving its definition in the header (my understanding is that compiler only sees the header so if the method is templated it could cause a "panic", but I'd like to know more) and adding `.template ` because of [this](https://en.cppreference.com/w/cpp/language/dependent_name).

Let me know what you think and if there is a more elegant solution. :)

