### PR TITLE
Refactor Configuration interface, add mock for it and add controller test

### DIFF
--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -8,15 +8,16 @@
 using json = nlohmann::json;
 
 namespace config {
-class Configuration : public ConfigurationInterface<json> {
+class Configuration : public ConfigurationInterface {
 public:
     explicit Configuration(std::filesystem::path filepath);
-    [[nodiscard]] bool LoadConfigurationFile() override;
-    [[nodiscard]] bool WriteConfigurationFile(json& jsonfile) override;
     [[nodiscard]] Setting GetSetting(ConfigurationName config_name) override;
-    [[nodiscard]] bool CreateDefaultConfigurationFile();
 
 private:
+    [[nodiscard]] bool LoadConfigurationFile();
+    [[nodiscard]] bool WriteConfigurationFile(json& jsonfile);
+    [[nodiscard]] bool CreateDefaultConfigurationFile();
+
     std::filesystem::path filepath_;
     json configData_;
 };

--- a/src/config/ConfigurationDefault.h
+++ b/src/config/ConfigurationDefault.h
@@ -9,13 +9,13 @@ namespace config {
 
 const std::vector<Setting> kDefaultConfig = {
     { ConfigurationName::kAngleSensorMaxValue,
-        M_PIf,
+        M_PI,
         std::nullopt,
         std::nullopt,
         "rad",
         "Maximum value of sensor's range" },
     { ConfigurationName::kAngleSensorMinValue,
-        -M_PIf,
+        -M_PI,
         std::nullopt,
         std::nullopt,
         "rad",

--- a/src/config/ConfigurationInterface.h
+++ b/src/config/ConfigurationInterface.h
@@ -5,32 +5,16 @@
 #include <string>
 
 namespace config {
-template <typename ConfigurationFileType>
 class ConfigurationInterface {
 public:
+    virtual ~ConfigurationInterface() = default;
     /**
-     * @brief Loads the content of the configuration file into a private member variable
+     * @brief Get the setting according to configuration name
      *
-     * @return true when loading successfully
-     * @return false when failing to load
-     */
-    virtual bool LoadConfigurationFile() = 0;
-    /**
-     * @brief Writes configuration data to file
-     *
-     * @param jsonfile
-     * @return true when writing successfully
-     * @return false when failing to write
-     */
-    virtual bool WriteConfigurationFile(ConfigurationFileType& jsonfile) = 0;
-    /**
-     * @brief Get a specific configuration from the private member variable
-     *
-     * @param ConfigName
-     * @return ConfigurationFileType
+     * @param config_name
+     * @return Setting
      */
     virtual Setting GetSetting(ConfigurationName config_name) = 0;
-    virtual ~ConfigurationInterface() = default;
 };
 
 } // namespace config

--- a/src/config/ConfigurationName.h
+++ b/src/config/ConfigurationName.h
@@ -24,7 +24,7 @@ enum class ConfigurationName {
  * @param config_name
  * @return std::string name of the configuration
  *
- * @remark 	Foo logging purposes but also to overload the << operator so that GTest can print the errors correctly
+ * @remark 	For logging purposes but also to overload the << operator so that GTest can print the errors correctly
  */
 inline std::string ToString(ConfigurationName config_name)
 {
@@ -51,9 +51,6 @@ inline std::string ToString(ConfigurationName config_name)
         return "kControllerIntegrativeGain";
     case ConfigurationName::kControllerDerivativeGain:
         return "kControllerDerivativeGain";
-
-        return {};
-        break;
     } // Don't add the default case, so that the compiler can warn you.
 }
 

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -3,6 +3,18 @@
 
 namespace controller {
 
+Controller::Controller(config::ConfigurationInterface& config, std::chrono::milliseconds cycle_time)
+    : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).Value<double>())
+    , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).Value<double>())
+    , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).Value<double>())
+    , error_(0.0)
+    , integral_part_(0.0)
+    , previous_error_(0.0)
+    , output_(0.0)
+    , cycle_time_(cycle_time)
+{
+}
+
 void Controller::Read(double error)
 {
     this->error_ = error;
@@ -17,8 +29,8 @@ double Controller::Write()
 void Controller::Calculate()
 {
     auto proportional_part = kp_ * error_;
-    this->integral_part_ += ki_ * error_ * static_cast<double>(dt_.count()); // This is an approximation of rectangle area below the curve, it could be improved to a trapezium.
-    auto derivative_part = kd_ * (error_ - previous_error_) / static_cast<double>(dt_.count());
+    this->integral_part_ += ki_ * error_ * static_cast<double>(cycle_time_.count()); // This is an approximation of rectangle area below the curve, it could be improved to a trapezium.
+    auto derivative_part = kd_ * (error_ - previous_error_) / static_cast<double>(cycle_time_.count());
     previous_error_ = error_;
 
     output_ = proportional_part + integral_part_ + derivative_part;

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -27,10 +27,10 @@ private:
     double kp_;
     double ki_;
     double kd_;
-    double integral_part_{};
-    double output_{};
-    double error_{};
-    double previous_error_{};
+    double integral_part_ {};
+    double output_ {};
+    double error_ {};
+    double previous_error_ {};
     std::chrono::microseconds dt_;
 };
 

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -1,7 +1,6 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
-#include "Configuration.h"
 #include "ConfigurationInterface.h"
 #include "ControllerInterface.h"
 #include <chrono>
@@ -10,28 +9,22 @@ namespace controller {
 
 class Controller : ControllerInterface<double, double> {
 public:
-    template <typename ConfigFileType>
-    Controller(config::ConfigurationInterface<ConfigFileType>& config, std::chrono::microseconds dt)
-        : kp_(config.GetSetting(config::ConfigurationName::kControllerProportionalGain).template Value<double>())
-        , ki_(config.GetSetting(config::ConfigurationName::kControllerIntegrativeGain).template Value<double>())
-        , kd_(config.GetSetting(config::ConfigurationName::kControllerDerivativeGain).template Value<double>())
-        , dt_(dt)
-    {
-    }
+    Controller(config::ConfigurationInterface& config, std::chrono::milliseconds cycle_time);
     ~Controller() override = default;
     void Read(double error) override;
     [[nodiscard]] double Write() override;
-    void Calculate();
 
 private:
+    void Calculate();
+
     double kp_;
     double ki_;
     double kd_;
-    double integral_part_ {};
-    double output_ {};
-    double error_ {};
-    double previous_error_ {};
-    std::chrono::microseconds dt_;
+    double integral_part_;
+    double output_;
+    double error_;
+    double previous_error_;
+    std::chrono::milliseconds cycle_time_;
 };
 
 } // namespace controller

--- a/src/controller/ControllerInterface.h
+++ b/src/controller/ControllerInterface.h
@@ -11,6 +11,6 @@ public:
     [[nodiscard]] virtual LogicalOutput Write() = 0;
 };
 
-}
+} // namespace controller
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 enable_testing()
 
+include_directories(mocks)
+
 add_subdirectory(config)
 add_subdirectory(controller)
 add_subdirectory(hal)

--- a/test/controller/ControllerTest.cpp
+++ b/test/controller/ControllerTest.cpp
@@ -1,0 +1,45 @@
+#include "Controller.h"
+#include "ConfigurationName.h"
+#include "MockConfig.h"
+#include "Setting.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace testing;
+
+namespace controller {
+
+class ControllerTest : public Test {
+    void SetUp() override
+    {
+        NiceMock<config::MockConfiguration> mock_config;
+        // Set up the mock to return the desired configuration settings.
+        ON_CALL(mock_config, GetSetting(config::ConfigurationName::kControllerProportionalGain)).WillByDefault(Return<config::Setting>(config::Setting {
+            .name = config::ConfigurationName::kControllerProportionalGain,
+            .value = 0.0,
+        }));
+        ON_CALL(mock_config, GetSetting(config::ConfigurationName::kControllerIntegrativeGain)).WillByDefault(Return<config::Setting>(config::Setting {
+            .name = config::ConfigurationName::kControllerIntegrativeGain,
+            .value = 0.1,
+        }));
+        ON_CALL(mock_config, GetSetting(config::ConfigurationName::kControllerDerivativeGain)).WillByDefault(Return<config::Setting>(config::Setting {
+            .name = config::ConfigurationName::kControllerDerivativeGain,
+            .value = 0.0,
+        }));
+
+        // Create a controller object using the mock configuration.
+        controller_ = std::make_unique<controller::Controller>(mock_config, std::chrono::milliseconds(1000));
+    }
+
+public:
+    std::unique_ptr<controller::Controller> controller_;
+};
+
+TEST_F(ControllerTest, calculate)
+{
+    // Verify that the controller calculated the correct output.
+    EXPECT_EQ(controller_->Write(), 0.0);
+}
+
+} // namespace controller

--- a/test/mocks/MockConfig.h
+++ b/test/mocks/MockConfig.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "ConfigurationInterface.h"
+#include <gmock/gmock.h>
+
+namespace config {
+
+class MockConfiguration : public ConfigurationInterface {
+public:
+    MOCK_METHOD(Setting, GetSetting, (ConfigurationName config_name), (override));
+};
+
+} // namespace config


### PR DESCRIPTION
First of all, this PR is target to your branch `no-json-in-config-injection`, so I created this separate PR so we can review this particular changes.
I was thinking about the config interface and it doesn't need to know which kind of serialization we need. 
In the end I added a test example for `Controller`, we need to extend it to cover all kind of scenarios.
I want to go through this changes with you, because I'd like to know if you agree 😄 