### PR TITLE
Add sanitizers for all targets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env: 
+      ASAN_OPTIONS: verify_asan_link_order=0
 
     strategy:
       fail-fast: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ find_package(absl CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(benchmark CONFIG REQUIRED)
 
+# Add path for custom modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(Sanitizer)
+
 option(STRICT_BUILD "Enable warnings as errors" ON)
 
 add_subdirectory(src)

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -1,0 +1,8 @@
+# Module for enabling/disabling sanitizers for all targets.
+
+option(ENABLE_SANITIZERS "Enable sanitizers" ON)
+
+if(ENABLE_SANITIZERS)
+    add_compile_options(-fsanitize=address,undefined,leak -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address,undefined,leak -fno-omit-frame-pointer)
+endif(ENABLE_SANITIZERS)

--- a/test/hal/AngleSensorTest.cpp
+++ b/test/hal/AngleSensorTest.cpp
@@ -1,9 +1,10 @@
 #include "AngleSensor.h"
 #include <gtest/gtest.h>
+#include <memory>
 
 TEST(AngleSensorTest, DummyTest)
 {
-    auto* angle_sensor = new hal::AngleSensor(42.0);
+    auto angle_sensor = std::make_unique<hal::AngleSensor>(42.0);
 
     EXPECT_EQ(angle_sensor->GetValue(1), 42.0);
 }

--- a/test/hello_test.cpp
+++ b/test/hello_test.cpp
@@ -8,3 +8,11 @@ TEST(HelloTest, BasicAssertions)
     // Expect equality.
     EXPECT_EQ(7 * 6, 42);
 }
+
+// Demonstrate a leaky test.
+TEST(HelloTest, DISABLED_LeakyTest)
+{
+    int* ptr;
+
+    ptr = new int(7);
+}


### PR DESCRIPTION
I added sanitizers to help us catch some bugs.

For example, the following leaky test was added:

```cpp
// Demonstrate a leaky test.
TEST(HelloTest, DISABLED_LeakyTest)
{
    int* ptr;

    ptr = new int(7); 
    // missing `deleter ptr;` so we have a leak here
}
```

Before the test will pass without no log or any evidence that we have a memory leakage (not even clangd will check this).
When we run this test we'll get the following log:

$35│ ==13973==ERROR: LeakSanitizer: detected memory leaks
$35│ 
$35│ Direct leak of 4 byte(s) in 1 object(s) allocated from:
$35│ 
$35│ ⬆ std::cerr
$35│ ⬇ std::cerr:
$35│     #0 0x5639f07e1e5d in operator new(unsigned long) (/workspaces/inverted-pendulum-controller/build/test/hello_test+0xfee5d) (BuildId: 347850db1c089c0c2a3bde69602f65ba32c160f6)
$35│     #1 0x5639f07e4af9 in HelloTest_LeakyTest_Test::TestBody() /workspaces/inverted-pendulum-controller/test/hello_test.cpp:17:11
$35│     #2 0x5639f082af14 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2621:27
$35│     #3 0x5639f0823154 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2657:52
$35│     #4 0x5639f07fcf77 in testing::Test::Run() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2696:50
$35│     #5 0x5639f07fda92 in testing::TestInfo::Run() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2845:14
$35│     #6 0x5639f07fe3df in testing::TestSuite::Run() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:3004:33
$35│     #7 0x5639f080e85d in testing::internal::UnitTestImpl::RunAllTests() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:5890:47
$35│     #8 0x5639f082bfbb in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2621:27
$35│     #9 0x5639f0824374 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:2657:52
$35│     #10 0x5639f080ce44 in testing::UnitTest::Run() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest.cc:5455:55
$35│     #11 0x5639f07e93a6 in RUN_ALL_TESTS() /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/include/gtest/gtest.h:2314:76
$35│     #12 0x5639f07e931f in main /usr/local/vcpkg/buildtrees/gtest/src/v1.13.0-0674f4ed11.clean/googletest/src/gtest_main.cc:63:23
$35│     #13 0x7f4efe2f4d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
$35│ 
$35│ 
$35│ ⬆ std::cerr
$35│ ⬇ std::cerr:
$35│ SUMMARY: AddressSanitizer: 4 byte(s) leaked in 1 allocation(s).
$35│ 
$35│ ⬆ std::cerr